### PR TITLE
Converting module references to WILDS Docker references

### DIFF
--- a/tg-wdl-VariantCaller/variantCalling-parameters.json
+++ b/tg-wdl-VariantCaller/variantCalling-parameters.json
@@ -20,8 +20,7 @@
         "/fh/fast/paguirigan_a/pub/ReferenceDataSets/genome_data/human/hg38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
         "/fh/fast/paguirigan_a/pub/ReferenceDataSets/genome_data/human/hg38/Homo_sapiens_assembly38.known_indels.vcf.gz"
       ],
-      "annovarDIR": "/fh/fast/paguirigan_a/pub/ReferenceDataSets/tool_specific_data/annovar/2018Apr16-ANNOVAR-2019Jan15-hg38humandb",
-      "annovar_protocols": "refGene,knownGene,dbnsfp35c,cosmic70,esp6500siv2_all,exac03,exac03nontcga,avsnp150,clinvar_20180603",
-      "annovar_operation": "g,f,f,f,f,f,f,f,f"
+      "annovar_protocols": "refGene,knownGene,cosmic70,esp6500siv2_all,clinvar_20180603,gnomad211_exome",
+      "annovar_operation": "g,f,f,f,f,f"
   }
 }


### PR DESCRIPTION
**Updates**

- Switching the docker containers used to the WILDS versions
    - Test run with input json executed successfully.
- Reducing the number of annovar protocols
    - Annovar docker container can't hold all of the reference data, hence the reduction in protocols.