### PR TITLE
Switching images from GHCR to DockerHub

### DIFF
--- a/helloDockerHostname/helloDockerHostname.wdl
+++ b/helloDockerHostname/helloDockerHostname.wdl
@@ -4,7 +4,7 @@ version 1.0
 
 #### WORKFLOW DEFINITION
 
-workflow HelloSingularityHostname {
+workflow HelloDockerHostname {
   call Hostname {
   }
 
@@ -32,6 +32,7 @@ task Hostname {
     cpu: 1
     memory: "1 GB"
     docker: "ubuntu:latest"
+    # modules: "Python/3.7.4-foss-2019b-fh1"
   }
 
   parameter_meta {

--- a/variantCalling/variantCalling.wdl
+++ b/variantCalling/variantCalling.wdl
@@ -53,9 +53,9 @@ workflow PanelBwaGatk4Annovar {
     ReferenceData reference_genome
   }
 
-  String gatk_docker = "ghcr.io/getwilds/gatk:4.3.0.0"
-  String annovar_docker = "ghcr.io/getwilds/annovar:${reference_genome.ref_name}"
-  String bwa_docker = "ghcr.io/getwilds/bwa:0.7.17"
+  String gatk_docker = "getwilds/gatk:4.3.0.0"
+  String annovar_docker = "getwilds/annovar:${reference_genome.ref_name}"
+  String bwa_docker = "getwilds/bwa:0.7.17"
 
   scatter (sample in sample_batch){
     File bam = sample.bam_file


### PR DESCRIPTION
## Description
- Switching Docker images from GHCR to DockerHub because of call caching issues 
- Also fixing a task name typo

## Related Issues
- Fixes #5 